### PR TITLE
Repo and skill rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ Install from this repository using `npx skills`.
 npx skills add google-gemini/gemini-skills --list
 
 # Install a specific skill.
-npx skills add google-gemini/gemini-skills --skill gemini-api --global
+npx skills add google-gemini/gemini-skills --skill gemini-api-dev --global
 ```
 
 ## Skills in this repo
 
-### gemini-api
+### gemini-api-dev
 
 Skill for developing Gemini-powered apps. Provides the best practices for
 building apps that use the Gemini API.
 
 ```sh
-npx skills add google-gemini/gemini-skills --skill gemini-api --global
+npx skills add google-gemini/gemini-skills --skill gemini-api-dev --global
 ```
 
 ## Disclaimer

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: gemini-api
+name: gemini-api-dev
 description: Use this skill when building applications with Gemini models, Gemini API, working with multimodal content (text, images, audio, video), implementing function calling, using structured outputs, or needing current model specifications. Covers SDK usage (google-genai for Python, @google/genai for JavaScript/TypeScript), model selection, and API capabilities.
 ---
 


### PR DESCRIPTION
Repo default name is now `gemini-skills`, and the skill is `gemini-api-dev`.