### PR TITLE
Add context7 skill instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx skills add google-gemini/gemini-skills --skill gemini-api-dev --global
 Or use the Context7 skills CLI.
 
 ```sh
-# Browse and install.
+# Interactively browse and install skills.
 npx ctx7 skills install /google-gemini/gemini-skills
 
 # Install a specific skill.


### PR DESCRIPTION
Wait until https://github.com/upstash/context7/pull/1730 is released before merging this. Once it supports Gemini CLI we can recommend it as a path for installation.