### PR TITLE
Optimize skills for MCP + Skill combo (96.3% eval pass rate)

### DIFF
--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -126,7 +126,7 @@ If the **`search_documentation`** tool (from the Google MCP server) is available
 
 1. Call `search_documentation` with your query
 2. Read the returned documentation
-3. **Immediately generate code** — do NOT use fallback URLs
+2. **Trust MCP results** as source of truth for API details — they are always up-to-date.
 
 > [!IMPORTANT]
 > When MCP tools are present, **never** fetch URLs manually. MCP provides up-to-date, indexed documentation that is more accurate and token-efficient than URL fetching.
@@ -152,14 +152,7 @@ Key pages:
 
 ---
 
-## Behavior Guidelines
 
-1. **Create code immediately** once you have necessary syntax. Do not over-research.
-2. **Strict stopping rule for MCP**: If you use an MCP tool (e.g., `search_documentation`) and receive content, you **must not** proceed to fallback lookups (e.g., searching `llms.txt`).
-3. **Trust MCP for current API specs**: MCP is the absolute source of truth for current model names, methods, and capabilities.
-4. **Trust Skill for safeguards**: Follow the Critical Rules strictly to avoid deprecated SDK packages or out-of-bounds configurations.
-
----
 
 ## Gemini Live API
 

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -20,10 +20,6 @@ description: Use this skill when building applications with Gemini models, Gemin
 - `gemini-2.5-pro`: 1M tokens, complex reasoning, coding, research
 - `gemini-2.5-flash`: 1M tokens, fast, balanced performance, multimodal
 
-### Current Agents (Use These)
-
-- `deep-research-pro-preview-12-2025`: Deep Research agent
-
 > [!WARNING]
 > Models like `gemini-2.0-*`, `gemini-1.5-*` are **legacy and deprecated**. Never use them.
 

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -12,12 +12,20 @@ description: Use this skill when building applications with Gemini models, Gemin
 
 ### Current Models (Use These)
 
-- `gemini-3-pro-preview`: 1M tokens, complex reasoning, coding, research
+- `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
 - `gemini-3-flash-preview`: 1M tokens, fast, balanced performance, multimodal
+- `gemini-3.1-flash-lite-preview`: cost-efficient, fastest performance for high-frequency, lightweight tasks
 - `gemini-3-pro-image-preview`: 65k / 32k tokens, image generation and editing
+- `gemini-3.1-flash-image-preview`: 65k / 32k tokens, image generation and editing
+- `gemini-2.5-pro`: 1M tokens, complex reasoning, coding, research
+- `gemini-2.5-flash`: 1M tokens, fast, balanced performance, multimodal
+
+### Current Agents (Use These)
+
+- `deep-research-pro-preview-12-2025`: Deep Research agent
 
 > [!WARNING]
-> Models like `gemini-2.5-*`, `gemini-2.0-*`, `gemini-1.5-*` are **legacy and deprecated**. Never use them.
+> Models like `gemini-2.0-*`, `gemini-1.5-*` are **legacy and deprecated**. Never use them.
 
 ### Current SDKs (Use These)
 
@@ -151,8 +159,6 @@ Key pages:
 - [SDK migration guide](https://ai.google.dev/gemini-api/docs/migrate.md.txt)
 
 ---
-
-
 
 ## Gemini Live API
 

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -122,7 +122,7 @@ public class GenerateTextFromTextInput {
 
 ### When MCP is Installed (Preferred)
 
-If the **`search_documentation`** tool is available, use it as your **only** documentation source:
+If the **`search_documentation`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
 
 1. Call `search_documentation` with your query
 2. Read the returned documentation
@@ -152,23 +152,12 @@ Key pages:
 
 ---
 
-## API Spec (Source of Truth)
-
-For exact field names, types, and supported operations, fetch the REST API discovery spec:
-
-- **v1beta** (default): `https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta`
-- **v1**: `https://generativelanguage.googleapis.com/$discovery/rest?version=v1`
-
-When in doubt, use v1beta. The official SDKs target v1beta.
-
----
-
 ## Behavior Guidelines
 
-1. **Generate code immediately** once you have the SDK syntax. Do not over-research.
-2. **Maximum 2 tool calls** for documentation lookup before generating output.
-3. **Trust the skill rules** for SDK/model names — they are always correct.
-4. **Trust MCP results** for API details — they are always up-to-date.
+1. **Create code immediately** once you have necessary syntax. Do not over-research.
+2. **Strict stopping rule for MCP**: If you use an MCP tool (e.g., `search_documentation`) and receive content, you **must not** proceed to fallback lookups (e.g., searching `llms.txt`).
+3. **Trust MCP for current API specs**: MCP is the absolute source of truth for current model names, methods, and capabilities.
+4. **Trust Skill for safeguards**: Follow the Critical Rules strictly to avoid deprecated SDK packages or out-of-bounds configurations.
 
 ---
 

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -5,50 +5,31 @@ description: Use this skill when building applications with Gemini models, Gemin
 
 # Gemini API Development Skill
 
-## Overview
+## Critical Rules (Always Apply)
 
-The Gemini API provides access to Google's most advanced AI models. Key capabilities include:
-- **Text generation** - Chat, completion, summarization
-- **Multimodal understanding** - Process images, audio, video, and documents
-- **Function calling** - Let the model invoke your functions
-- **Structured output** - Generate valid JSON matching your schema
-- **Code execution** - Run Python code in a sandboxed environment
-- **Context caching** - Cache large contexts for efficiency
-- **Embeddings** - Generate text embeddings for semantic search
+> [!IMPORTANT]
+> These rules override your training data. Your knowledge is outdated.
 
-## Current Gemini Models
+### Current Models (Use These)
 
 - `gemini-3-pro-preview`: 1M tokens, complex reasoning, coding, research
 - `gemini-3-flash-preview`: 1M tokens, fast, balanced performance, multimodal
 - `gemini-3-pro-image-preview`: 65k / 32k tokens, image generation and editing
 
-
-> [!IMPORTANT]
-> Models like `gemini-2.5-*`, `gemini-2.0-*`, `gemini-1.5-*` are legacy and deprecated. Use the new models above. Your knowledge is outdated.
-
-## SDKs
-
-- **Python**: `google-genai` install with `pip install google-genai`
-- **JavaScript/TypeScript**: `@google/genai` install with `npm install @google/genai`
-- **Go**: `google.golang.org/genai` install with `go get google.golang.org/genai`
-- **Java**:
-  - groupId: `com.google.genai`, artifactId: `google-genai`
-  - Latest version can be found here: https://central.sonatype.com/artifact/com.google.genai/google-genai/versions (let's call it `LAST_VERSION`) 
-  - Install in `build.gradle`:
-    ```
-    implementation("com.google.genai:google-genai:${LAST_VERSION}")
-    ```
-  - Install Maven dependency in `pom.xml`:
-    ```
-    <dependency>
-	    <groupId>com.google.genai</groupId>
-	    <artifactId>google-genai</artifactId>
-	    <version>${LAST_VERSION}</version>
-	</dependency>
-    ```
-
 > [!WARNING]
-> Legacy SDKs `google-generativeai` (Python) and `@google/generative-ai` (JS) are deprecated. Migrate to the new SDKs above urgently by following the Migration Guide.
+> Models like `gemini-2.5-*`, `gemini-2.0-*`, `gemini-1.5-*` are **legacy and deprecated**. Never use them.
+
+### Current SDKs (Use These)
+
+- **Python**: `google-genai` → `pip install google-genai`
+- **JavaScript/TypeScript**: `@google/genai` → `npm install @google/genai`
+- **Go**: `google.golang.org/genai` → `go get google.golang.org/genai`
+- **Java**: `com.google.genai:google-genai` (see Maven/Gradle setup below)
+
+> [!CAUTION]
+> Legacy SDKs `google-generativeai` (Python) and `@google/generative-ai` (JS) are **deprecated**. Never use them.
+
+---
 
 ## Quick Start
 
@@ -123,43 +104,73 @@ public class GenerateTextFromTextInput {
 }
 ```
 
-## API spec (source of truth)
+**Java Installation:**
+- Latest version: https://central.sonatype.com/artifact/com.google.genai/google-genai/versions
+- Gradle: `implementation("com.google.genai:google-genai:${LAST_VERSION}")`
+- Maven:
+  ```xml
+  <dependency>
+      <groupId>com.google.genai</groupId>
+      <artifactId>google-genai</artifactId>
+      <version>${LAST_VERSION}</version>
+  </dependency>
+  ```
 
-**Always use the latest REST API discovery spec as the source of truth for API definitions** (request/response schemas, parameters, methods). Fetch the spec when implementing or debugging API integration:
+---
 
-- **v1beta** (default): `https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta`  
-  Use this unless the integration is explicitly pinned to v1. The official SDKs (google-genai, @google/genai, google.golang.org/genai) target v1beta.
-- **v1**: `https://generativelanguage.googleapis.com/$discovery/rest?version=v1`  
-  Use only when the integration is specifically set to v1.
+## Documentation Lookup
 
-When in doubt, use v1beta. Refer to the spec for exact field names, types, and supported operations.
+### When MCP is Installed (Preferred)
 
-## How to use the Gemini API
+If the **`search_documentation`** tool is available, use it as your **only** documentation source:
 
-For detailed API documentation, fetch from the official docs index:
-
-**llms.txt URL**: `https://ai.google.dev/gemini-api/docs/llms.txt`
-
-This index contains links to all documentation pages in `.md.txt` format. Use web fetch tools to:
-
-1. Fetch `llms.txt` to discover available documentation pages
-2. Fetch specific pages (e.g., `https://ai.google.dev/gemini-api/docs/function-calling.md.txt`)
-
-### Key Documentation Pages 
+1. Call `search_documentation` with your query
+2. Read the returned documentation
+3. **Immediately generate code** — do NOT use fallback URLs
 
 > [!IMPORTANT]
-> Those are not all the documentation pages. Use the `llms.txt` index to discover available documentation pages
+> When MCP tools are present, **never** fetch URLs manually. MCP provides up-to-date, indexed documentation that is more accurate and token-efficient than URL fetching.
 
-- [Models](https://ai.google.dev/gemini-api/docs/models.md.txt)
-- [Google AI Studio quickstart](https://ai.google.dev/gemini-api/docs/ai-studio-quickstart.md.txt)
-- [Nano Banana image generation](https://ai.google.dev/gemini-api/docs/image-generation.md.txt)
-- [Function calling with the Gemini API](https://ai.google.dev/gemini-api/docs/function-calling.md.txt)
-- [Structured outputs](https://ai.google.dev/gemini-api/docs/structured-output.md.txt)
+### When MCP is NOT Installed (Fallback Only)
+
+If no MCP documentation tools are available, fetch from the official docs:
+
+**Index URL**: `https://ai.google.dev/gemini-api/docs/llms.txt`
+
+Use `fetch_url` to:
+1. Fetch `llms.txt` to discover available pages
+2. Fetch specific pages (e.g., `https://ai.google.dev/gemini-api/docs/function-calling.md.txt`)
+
+Key pages:
 - [Text generation](https://ai.google.dev/gemini-api/docs/text-generation.md.txt)
+- [Function calling](https://ai.google.dev/gemini-api/docs/function-calling.md.txt)
+- [Structured outputs](https://ai.google.dev/gemini-api/docs/structured-output.md.txt)
+- [Image generation](https://ai.google.dev/gemini-api/docs/image-generation.md.txt)
 - [Image understanding](https://ai.google.dev/gemini-api/docs/image-understanding.md.txt)
 - [Embeddings](https://ai.google.dev/gemini-api/docs/embeddings.md.txt)
-- [Interactions API](https://ai.google.dev/gemini-api/docs/interactions.md.txt)
 - [SDK migration guide](https://ai.google.dev/gemini-api/docs/migrate.md.txt)
+
+---
+
+## API Spec (Source of Truth)
+
+For exact field names, types, and supported operations, fetch the REST API discovery spec:
+
+- **v1beta** (default): `https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta`
+- **v1**: `https://generativelanguage.googleapis.com/$discovery/rest?version=v1`
+
+When in doubt, use v1beta. The official SDKs target v1beta.
+
+---
+
+## Behavior Guidelines
+
+1. **Generate code immediately** once you have the SDK syntax. Do not over-research.
+2. **Maximum 2 tool calls** for documentation lookup before generating output.
+3. **Trust the skill rules** for SDK/model names — they are always correct.
+4. **Trust MCP results** for API details — they are always up-to-date.
+
+---
 
 ## Gemini Live API
 

--- a/skills/gemini-interactions-api/SKILL.md
+++ b/skills/gemini-interactions-api/SKILL.md
@@ -269,7 +269,7 @@ An `Interaction` response contains `outputs` — an array of typed content block
 
 ### When MCP is Installed (Preferred)
 
-If the **`search_documentation`** tool is available, use it as your **only** documentation source:
+If the **`search_documentation`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
 
 1. Call `search_documentation` with your query
 2. Read the returned documentation
@@ -284,8 +284,6 @@ If no MCP documentation tools are available, fetch from the official docs:
 
 - [Interactions Full Documentation](https://ai.google.dev/gemini-api/docs/interactions.md.txt)
 - [Deep Research Full Documentation](https://ai.google.dev/gemini-api/docs/deep-research.md.txt)
-- [API Reference](https://ai.google.dev/static/api/interactions.md.txt)
-- [OpenAPI Spec](https://ai.google.dev/static/api/interactions.openapi.json)
 
 These pages cover function calling, built-in tools (Google Search, code execution, URL context, file search, computer use), remote MCP, structured output, thinking configuration, working with files, multimodal understanding and generation, streaming events, and more.
 
@@ -293,7 +291,7 @@ These pages cover function calling, built-in tools (Google Search, code executio
 
 ## Behavior Guidelines
 
-1. **Generate code immediately** once you have the SDK syntax. Do not over-research.
-2. **Maximum 2 tool calls** for documentation lookup before generating output.
-3. **Trust the skill rules** for SDK/model names — they are always correct.
-4. **Trust MCP results** for API details — they are always up-to-date.
+1. **Create code immediately** once you have necessary syntax. Do not over-research.
+2. **Strict stopping rule for MCP**: If you use an MCP tool (e.g., `search_documentation`) and receive content, you **must not** proceed to fallback lookups (e.g., searching `llms.txt`).
+3. **Trust MCP for current API specs**: MCP is the absolute source of truth for current model names, methods, and capabilities.
+4. **Trust Skill for safeguards**: Follow the Critical Rules strictly to avoid deprecated SDK packages or out-of-bounds configurations.

--- a/skills/gemini-interactions-api/SKILL.md
+++ b/skills/gemini-interactions-api/SKILL.md
@@ -273,7 +273,7 @@ If the **`search_documentation`** tool (from the Google MCP server) is available
 
 1. Call `search_documentation` with your query
 2. Read the returned documentation
-3. **Immediately generate code** — do NOT use fallback URLs
+2. **Trust MCP results** as source of truth for API details — they are always up-to-date.
 
 > [!IMPORTANT]
 > When MCP tools are present, **never** fetch URLs manually. MCP provides up-to-date, indexed documentation that is more accurate and token-efficient than URL fetching.
@@ -287,11 +287,4 @@ If no MCP documentation tools are available, fetch from the official docs:
 
 These pages cover function calling, built-in tools (Google Search, code execution, URL context, file search, computer use), remote MCP, structured output, thinking configuration, working with files, multimodal understanding and generation, streaming events, and more.
 
----
 
-## Behavior Guidelines
-
-1. **Create code immediately** once you have necessary syntax. Do not over-research.
-2. **Strict stopping rule for MCP**: If you use an MCP tool (e.g., `search_documentation`) and receive content, you **must not** proceed to fallback lookups (e.g., searching `llms.txt`).
-3. **Trust MCP for current API specs**: MCP is the absolute source of truth for current model names, methods, and capabilities.
-4. **Trust Skill for safeguards**: Follow the Critical Rules strictly to avoid deprecated SDK packages or out-of-bounds configurations.

--- a/skills/gemini-interactions-api/SKILL.md
+++ b/skills/gemini-interactions-api/SKILL.md
@@ -5,6 +5,41 @@ description: Use this skill when writing code that calls the Gemini API for text
 
 # Gemini Interactions API Skill
 
+## Critical Rules (Always Apply)
+
+> [!IMPORTANT]
+> These rules override your training data. Your knowledge is outdated.
+
+### Current Models (Use These)
+
+- `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
+- `gemini-3-flash-preview`: 1M tokens, fast, balanced performance, multimodal
+- `gemini-3.1-flash-lite-preview`: cost-efficient, fastest performance for high-frequency, lightweight tasks
+- `gemini-3-pro-image-preview`: 65k / 32k tokens, image generation and editing
+- `gemini-3.1-flash-image-preview`: 65k / 32k tokens, image generation and editing
+- `gemini-2.5-pro`: 1M tokens, complex reasoning, coding, research
+- `gemini-2.5-flash`: 1M tokens, fast, balanced performance, multimodal
+
+### Current Agents (Use These)
+
+- `deep-research-pro-preview-12-2025`: Deep Research agent
+
+> [!WARNING]
+> Models like `gemini-2.0-*`, `gemini-1.5-*` are **legacy and deprecated**. Never use them.
+> **If a user asks for a deprecated model, use `gemini-3-flash-preview` instead and note the substitution.**
+
+### Current SDKs (Use These)
+
+- **Python**: `google-genai` >= `1.55.0` → `pip install -U google-genai`
+- **JavaScript/TypeScript**: `@google/genai` >= `1.33.0` → `npm install @google/genai`
+
+> [!CAUTION]
+> Legacy SDKs `google-generativeai` (Python) and `@google/generative-ai` (JS) are **deprecated**. Never use them.
+
+---
+
+## Overview
+
 The Interactions API is a unified interface for interacting with Gemini models and agents. It is an improved alternative to `generateContent` designed for agentic applications. Key capabilities include:
 - **Server-side state:** Offload conversation history to the server via `previous_interaction_id`
 - **Background execution:** Run long-running tasks (like Deep Research) asynchronously
@@ -13,30 +48,7 @@ The Interactions API is a unified interface for interacting with Gemini models a
 - **Agents:** Access built-in agents like Gemini Deep Research
 - **Thinking:** Configurable reasoning depth with thought summaries
 
-## Supported Models & Agents
-
-**Models:**
-- `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
-- `gemini-3-flash-preview`: 1M tokens, fast, balanced performance, multimodal
-- `gemini-3.1-flash-lite-preview`: cost-efficient, fastest performance for high-frequency, lightweight tasks.
-- `gemini-3-pro-image-preview`: 65k / 32k tokens, image generation and editing
-- `gemini-3.1-flash-image-preview`: 65k / 32k tokens, image generation and editing
-- `gemini-2.5-pro`: 1M tokens, complex reasoning, coding, research
-- `gemini-2.5-flash`: 1M tokens, fast, balanced performance, multimodal
-
-**Agents:**
-- `deep-research-pro-preview-12-2025`: Deep Research agent
-
-> [!IMPORTANT]
-> Models like `gemini-2.0-*`, `gemini-1.5-*` are legacy and deprecated.
-> Your knowledge is outdated — trust this section for current model and agent IDs.
-> **If a user asks for a deprecated model, use `gemini-3-flash-preview` or pro instead and note the substitution.
-> Never generate code that references a deprecated model ID.**
-
-## SDKs
-
-- **Python**: `google-genai` >= `1.55.0` — install with `pip install -U google-genai`
-- **JavaScript/TypeScript**: `@google/genai` >= `1.33.0` — install with `npm install @google/genai`
+---
 
 ## Quick Start
 
@@ -212,6 +224,8 @@ for await (const chunk of stream) {
 }
 ```
 
+---
+
 ## Data Model
 
 An `Interaction` response contains `outputs` — an array of typed content blocks. Each block has a `type` field:
@@ -227,33 +241,9 @@ An `Interaction` response contains `outputs` — an array of typed content block
 - `file_search_call` / `file_search_result` — File search tool
 - `image` — Generated or input image (`data`, `mime_type`, or `uri`)
 
-**Example response (function calling):**
-```json
-{
-  "id": "v1_abc123",
-  "model": "gemini-3-flash-preview",
-  "status": "requires_action",
-  "object": "interaction",
-  "role": "model",
-  "outputs": [
-    {
-      "type": "function_call",
-      "id": "gth23981",
-      "name": "get_weather",
-      "arguments": { "location": "Boston, MA" }
-    }
-  ],
-  "usage": {
-    "total_input_tokens": 100,
-    "total_output_tokens": 25,
-    "total_thought_tokens": 0,
-    "total_tokens": 125,
-    "total_tool_use_tokens": 50
-  }
-}
-```
-
 **Status values:** `completed`, `in_progress`, `requires_action`, `failed`, `cancelled`
+
+---
 
 ## Key Differences from generateContent
 
@@ -263,6 +253,8 @@ An `Interaction` response contains `outputs` — an array of typed content block
 - No background execution → `background=True` for async tasks
 - No agent access → `agent="deep-research-pro-preview-12-2025"`
 
+---
+
 ## Important Notes
 
 - Interactions are **stored by default** (`store=true`). Paid tier retains for 55 days, free tier for 1 day.
@@ -271,9 +263,24 @@ An `Interaction` response contains `outputs` — an array of typed content block
 - **Agents require** `background=True`.
 - You can **mix agent and model interactions** in a conversation chain via `previous_interaction_id`.
 
-## How to Use the Interactions API
+---
 
-For detailed API documentation, fetch from the official docs:
+## Documentation Lookup
+
+### When MCP is Installed (Preferred)
+
+If the **`search_documentation`** tool is available, use it as your **only** documentation source:
+
+1. Call `search_documentation` with your query
+2. Read the returned documentation
+3. **Immediately generate code** — do NOT use fallback URLs
+
+> [!IMPORTANT]
+> When MCP tools are present, **never** fetch URLs manually. MCP provides up-to-date, indexed documentation that is more accurate and token-efficient than URL fetching.
+
+### When MCP is NOT Installed (Fallback Only)
+
+If no MCP documentation tools are available, fetch from the official docs:
 
 - [Interactions Full Documentation](https://ai.google.dev/gemini-api/docs/interactions.md.txt)
 - [Deep Research Full Documentation](https://ai.google.dev/gemini-api/docs/deep-research.md.txt)
@@ -281,3 +288,12 @@ For detailed API documentation, fetch from the official docs:
 - [OpenAPI Spec](https://ai.google.dev/static/api/interactions.openapi.json)
 
 These pages cover function calling, built-in tools (Google Search, code execution, URL context, file search, computer use), remote MCP, structured output, thinking configuration, working with files, multimodal understanding and generation, streaming events, and more.
+
+---
+
+## Behavior Guidelines
+
+1. **Generate code immediately** once you have the SDK syntax. Do not over-research.
+2. **Maximum 2 tool calls** for documentation lookup before generating output.
+3. **Trust the skill rules** for SDK/model names — they are always correct.
+4. **Trust MCP results** for API details — they are always up-to-date.

--- a/skills/gemini-live-api-dev/SKILL.md
+++ b/skills/gemini-live-api-dev/SKILL.md
@@ -224,9 +224,22 @@ if (content?.interrupted) { /* Stop playback, clear audio queue */ }
 6. **Send `audioStreamEnd`** when the mic is paused to flush cached audio
 7. **Clear audio playback queues** on interruption signals
 
-## How to use the Gemini API
+## Documentation Lookup
 
-For detailed API documentation, fetch from the official docs index:
+### When MCP is Installed (Preferred)
+
+If the **`search_documentation`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
+
+1. Call `search_documentation` with your query
+2. Read the returned documentation
+3. **Trust MCP results** as source of truth for API details — they are always up-to-date.
+
+> [!IMPORTANT]
+> When MCP tools are present, **never** fetch URLs manually. MCP provides up-to-date, indexed documentation that is more accurate and token-efficient than URL fetching.
+
+### When MCP is NOT Installed (Fallback Only)
+
+If no MCP documentation tools are available, fetch from the official docs index:
 
 **llms.txt URL**: `https://ai.google.dev/gemini-api/docs/llms.txt`
 


### PR DESCRIPTION
- Add 'Critical Rules' section at top with SDK/model deprecation warnings
- Add 'Documentation Lookup' section with MCP-first instructions
- Add 'Behavior Guidelines' section to prevent over-research
- Restructure for clearer visual hierarchy with dividers

Evaluation results (gemini-3.1-flash-lite):
- Vanilla: 7.7% pass rate
- MCP Only: 72.6% pass rate
- Skill Only: 82.9% pass rate
- Skill+MCP (optimized): 96.3% pass rate

The key insight: when MCP is available, instruct the model to use it as the ONLY documentation source and generate code immediately.