### PR TITLE
docs: add Gemini Docs MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ npx ctx7 skills install /google-gemini/gemini-skills
 npx ctx7 skills install /google-gemini/gemini-skills vertex-ai-api-dev
 ```
 
-## Gemini Docs MCP
+## Gemini API docs MCP
 
-Gemini hosts a public Model Context Protocol (MCP) server at
+A public Model Context Protocol (MCP) server for the Gemini API is available at
 `https://gemini-api-docs-mcp.dev`. Connecting your coding agent to this server ensures that
 all queries have access to the latest APIs, code updates, and optimal configuration examples.
 
@@ -70,11 +70,15 @@ the server:
 
 This server adds a `search_docs` function that your agent can use to
 retrieve real-time API definitions and integration patterns from the official
-Gemini documentation files.
+Gemini API documentation.
 
-## More Installation Documentation
+Note that the `gemini-api-dev` skill works with or without the MCP server, so
+we recommend installing them both.
 
-You can find additional information about setting up your coding assistant with Gemini MCP and Skills here: https://ai.google.dev/gemini-api/docs/coding-agents
+## More info
+
+You can find additional information about setting up your coding assistant with
+Gemini API MCP and Skills in [the docs](https://ai.google.dev/gemini-api/docs/coding-agents).
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the server:
 
     npx add-mcp "https://gemini-api-docs-mcp.dev"
 
-This server adds a `search_documentation` function that your agent can use to
+This server adds a `search_docs` function that your agent can use to
 retrieve real-time API definitions and integration patterns from the official
 Gemini documentation files.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the server:
 
     npx add-mcp "https://gemini-api-docs-mcp.dev"
 
-This server adds a `search_docs` function that your agent can use to
+This server adds a `search_docs` tool that your agent can use to
 retrieve real-time API definitions and integration patterns from the official
 Gemini API documentation.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ npx ctx7 skills install /google-gemini/gemini-skills
 npx ctx7 skills install /google-gemini/gemini-skills vertex-ai-api-dev
 ```
 
+## Gemini Docs MCP
+
+Gemini hosts a public Model Context Protocol (MCP) server at
+`https://gemini-api-docs-mcp.dev`. Connecting your coding agent to this server ensures that
+all queries have access to the latest APIs, code updates, and optimal configuration examples.
+
+Run the following command in your agent's terminal or project root to install
+the server:
+
+    npx add-mcp "https://gemini-api-docs-mcp.dev"
+
+This server adds a `search_documentation` function that your agent can use to
+retrieve real-time API definitions and integration patterns from the official
+Gemini documentation files.
+
+## More Installation Documentation
+
+You can find additional information about setting up your coding assistant with Gemini MCP and Skills here: https://ai.google.dev/gemini-api/docs/coding-agents
+
 ## Disclaimer
 
 This is not an officially supported Google product. This project is not

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -128,9 +128,9 @@ public class GenerateTextFromTextInput {
 
 ### When MCP is Installed (Preferred)
 
-If the **`search_documentation`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
+If the **`search_docs`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
 
-1. Call `search_documentation` with your query
+1. Call `search_docs` with your query
 2. Read the returned documentation
 2. **Trust MCP results** as source of truth for API details — they are always up-to-date.
 

--- a/skills/gemini-interactions-api/SKILL.md
+++ b/skills/gemini-interactions-api/SKILL.md
@@ -277,9 +277,9 @@ An `Interaction` response contains `outputs` — an array of typed content block
 
 ### When MCP is Installed (Preferred)
 
-If the **`search_documentation`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
+If the **`search_docs`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
 
-1. Call `search_documentation` with your query
+1. Call `search_docs` with your query
 2. Read the returned documentation
 2. **Trust MCP results** as source of truth for API details — they are always up-to-date.
 

--- a/skills/gemini-live-api-dev/SKILL.md
+++ b/skills/gemini-live-api-dev/SKILL.md
@@ -248,9 +248,9 @@ When migrating from `gemini-2.5-flash-native-audio-preview-12-2025` to `gemini-3
 
 ### When MCP is Installed (Preferred)
 
-If the **`search_documentation`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
+If the **`search_docs`** tool (from the Google MCP server) is available, use it as your **only** documentation source:
 
-1. Call `search_documentation` with your query
+1. Call `search_docs` with your query
 2. Read the returned documentation
 3. **Trust MCP results** as source of truth for API details — they are always up-to-date.
 


### PR DESCRIPTION
Documentation update to include the Gemini Docs MCP server and a link back to the official docs.

Closes https://github.com/google-gemini/gemini-skills/issues/33