### PR TITLE
fix: define model literal and add types prefix in URL Context example

### DIFF
--- a/skills/vertex-ai-api-dev/references/structured_and_tools.md
+++ b/skills/vertex-ai-api-dev/references/structured_and_tools.md
@@ -116,9 +116,9 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model=model_id,
+    model="gemini-3-flash-preview",
     contents="Compare recipes from http://example.com and http://example2.com",
-    config=GenerateContentConfig(
+    config=types.GenerateContentConfig(
         tools=[types.Tool(url_context=types.UrlContext)],
     )
 )


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter. Please evaluate the diff on its merits.

The Url Context code sample in `skills/vertex-ai-api-dev/references/structured_and_tools.md` (the block under `## Url Context`) has two issues that prevent it from running as written:

1. **`model=model_id`** — `model_id` is never defined in the snippet (every other code block in the same file uses a literal model string). Copy-pasting this example raises `NameError: name 'model_id' is not defined`.
2. **`config=GenerateContentConfig(...)`** — the file imports the SDK as `from google.genai import types`, so the constructor must be qualified as `types.GenerateContentConfig(...)`. The four sibling examples in the same file (Structured Output, Function Calling, Search Grounding, Code Execution) all use the qualified form.

The fix matches the rest of the file:

```python
response = client.models.generate_content(
    model="gemini-3-flash-preview",
    contents="Compare recipes from http://example.com and http://example2.com",
    config=types.GenerateContentConfig(
        tools=[types.Tool(url_context=types.UrlContext)],
    )
)
```

The other code blocks in the same file already use `gemini-3-flash-preview`, so it's the conservative pick for consistency.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-undefined-variable","fingerprint":"sha256:3439ae24033ea4eca837d06d4a3e78c2f08ec906b1d97b08486edef14e2937c9"}]}
nlpm-metadata-end -->