### PR TITLE
fix: use agent-neutral phrasing for web-fetch fallback in gemini-api-dev

### DIFF
--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -143,7 +143,7 @@ If no MCP documentation tools are available, fetch from the official docs:
 
 **Index URL**: `https://ai.google.dev/gemini-api/docs/llms.txt`
 
-Use `fetch_url` to:
+Use web fetch tools to:
 1. Fetch `llms.txt` to discover available pages
 2. Fetch specific pages (e.g., `https://ai.google.dev/gemini-api/docs/function-calling.md.txt`)
 

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -143,7 +143,7 @@ If no MCP documentation tools are available, fetch from the official docs:
 
 **Index URL**: `https://ai.google.dev/gemini-api/docs/llms.txt`
 
-Use web fetch tools to:
+This index contains links to all documentation pages in .md.txt format. Use web fetch tools to:
 1. Fetch `llms.txt` to discover available pages
 2. Fetch specific pages (e.g., `https://ai.google.dev/gemini-api/docs/function-calling.md.txt`)
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter. Please evaluate the diff on its merits.

The "When MCP is NOT Installed (Fallback Only)" section in `skills/gemini-api-dev/SKILL.md` line 146 currently reads:

> Use \`fetch_url\` to:

The backticks read as a tool name, but none of the host agents this repo targets expose a tool literally named `fetch_url`:
- Claude Code's built-in is `WebFetch`
- Cursor and the other listed agents have their own naming
- The Vercel skills CLI / Context7 CLI listed in the README don't define this name

The sibling skill in the same repo, `gemini-live-api-dev/SKILL.md` line 266, already uses agent-neutral phrasing for the same fallback pattern:

> Use web fetch tools to:

This PR aligns the gemini-api-dev skill with the same wording so each host agent routes the fetch through whatever tool it actually exposes, instead of looking for a literal `fetch_url`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-undeclared-tool","fingerprint":"sha256:fc97b7500e81f2a6ab9c904c9a8cd8f56b2199676b15932ae7566bcb0f99ceac"}]}
nlpm-metadata-end -->