### PR TITLE
docs: fix README link text "thought circulation" → "thought signatures"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and best practices evolve quickly.
 This leaves a knowledge gap that language models can't solve on their own. For
 example, models don't know about themselves when they're trained, and they
 aren't necessarily aware of subtle changes in best practices (like [thought
-circulation](https://ai.google.dev/gemini-api/docs/thinking#signatures)) or SDK
+signatures](https://ai.google.dev/gemini-api/docs/thinking#signatures)) or SDK
 changes.
 
 [Skills](https://agentskills.io/) are a lightweight technique for adding

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and best practices evolve quickly.
 This leaves a knowledge gap that language models can't solve on their own. For
 example, models don't know about themselves when they're trained, and they
 aren't necessarily aware of subtle changes in best practices (like [thought
-signatures](https://ai.google.dev/gemini-api/docs/thinking#signatures)) or SDK
+circulation](https://ai.google.dev/gemini-api/docs/thought-signatures)) or SDK
 changes.
 
 [Skills](https://agentskills.io/) are a lightweight technique for adding


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter. Please evaluate the diff on its merits.

The README on line 14 links the phrase **"thought circulation"** to `https://ai.google.dev/gemini-api/docs/thinking#signatures`. The page section at that anchor is titled **"Thought signatures"**, and the underlying SDK field is exposed as `signature` (also referenced in `skills/gemini-interactions-api/SKILL.md` line 246).

This is a small label/destination mismatch — a reader who follows the link finds a section about "thought signatures" rather than the "thought circulation" promised in the prose. Updating the visible link text aligns the README with the actual API terminology used everywhere else in this repo and in Google's docs.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-link-text-mismatch","fingerprint":"sha256:5798b0c47a62e2886ddbdbd6fbfeed259cbe3c361ece2397e36b2d2b26da52f8"}]}
nlpm-metadata-end -->