### PR TITLE
fix(gemini-api-dev): use GA model codes, drop retired -preview suffixes

### DIFF
--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -14,9 +14,9 @@ description: Use this skill when building applications with Gemini API hosted mo
 
 - `gemini-3.5-flash`: 1M tokens, fast, balanced performance, multimodal
 - `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
-- `gemini-3.1-flash-lite-preview`: cost-efficient, fastest performance for high-frequency, lightweight tasks
-- `gemini-3-pro-image-preview`: 65k / 32k tokens, image generation and editing
-- `gemini-3.1-flash-image-preview`: 65k / 32k tokens, image generation and editing
+- `gemini-3.1-flash-lite`: cost-efficient, fastest performance for high-frequency, lightweight tasks
+- `gemini-3-pro-image`: 65k / 32k tokens, image generation and editing
+- `gemini-3.1-flash-image`: 65k / 32k tokens, image generation and editing
 - `gemini-2.5-pro`: 1M tokens, complex reasoning, coding, research
 - `gemini-2.5-flash`: 1M tokens, fast, balanced performance, multimodal
 - `gemma-4-31b-it`: Gemma 4 dense model, 31B parameters


### PR DESCRIPTION
## What

The `gemini-api-dev` skill's **Current Models (Use These)** list recommends three preview model codes that are now retired or superseded by their GA releases. This swaps them for the stable GA codes:

| Skill listed (preview) | GA code | Note |
|---|---|---|
| `gemini-3.1-flash-lite-preview` | `gemini-3.1-flash-lite` | the `-preview` build **shut down 2026-05-25**; GA is stable |
| `gemini-3-pro-image-preview` | `gemini-3-pro-image` | GA "Nano Banana Pro"; `-preview` shuts down 2026-06-25 |
| `gemini-3.1-flash-image-preview` | `gemini-3.1-flash-image` | GA "Nano Banana 2"; `-preview` shuts down 2026-06-25 |

`gemini-3.1-pro-preview` is intentionally left unchanged — no stable GA code exists for it yet.

## Why

A skill whose explicit purpose is "current model specifications" was steering callers onto a model code that has already been shut down (`gemini-3.1-flash-lite-preview`), which fails at call time, plus two image codes about to be retired in favor of their GA names.

## Verification

Checked each code against the live docs at https://ai.google.dev/gemini-api/docs:
- **models** and **pricing** pages list `gemini-3.1-flash-lite`, `gemini-3-pro-image`, and `gemini-3.1-flash-image` as the stable GA codes.
- **deprecations** page / changelog: `gemini-3.1-flash-lite-preview` shutdown 2026-05-25; the two `-image-preview` codes shutdown 2026-06-25.

Three-line change, no behavior beyond the model list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)