### PR TITLE
feat(audio): add Gemini 3.5 Transcribe (unary and live) support

### DIFF
--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -15,6 +15,7 @@ description: Use this skill when building applications with Gemini API hosted mo
 - `gemini-3.7-flash`: 1M tokens, fast, balanced performance for agentic and multimodal tasks
 - `gemini-3.5-flash-lite`: 1M tokens, fastest, lowest-cost 3.5 model for high-throughput execution
 - `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
+- `gemini-3.5-transcribe`: fast speech-to-text with smart and verbatim modes
 - `gemini-3-pro-image-preview` (Nano Banana Pro): 65k / 32k tokens, image generation and editing
 - `gemini-3.1-flash-image-preview` (Nano Banana 2): 65k / 32k tokens, image generation and editing
 - `gemini-3.1-flash-lite-image-preview` (Nano Banana 2 Lite): 65k / 32k tokens, ultra-fast image generation and editing
@@ -154,6 +155,7 @@ Key pages:
 - [Text generation](https://ai.google.dev/gemini-api/docs/text-generation.md.txt)
 - [Function calling](https://ai.google.dev/gemini-api/docs/function-calling.md.txt)
 - [Structured outputs](https://ai.google.dev/gemini-api/docs/structured-output.md.txt)
+- [Audio Transcription](https://ai.google.dev/gemini-api/docs/generate-content/transcribe.md.txt)
 - [Image generation](https://ai.google.dev/gemini-api/docs/image-generation.md.txt)
 - [Image understanding](https://ai.google.dev/gemini-api/docs/image-understanding.md.txt)
 - [Embeddings](https://ai.google.dev/gemini-api/docs/embeddings.md.txt)

--- a/skills/gemini-interactions-api/SKILL.md
+++ b/skills/gemini-interactions-api/SKILL.md
@@ -16,6 +16,7 @@ description: Use this skill when writing code that calls the Gemini API for text
 - `gemini-3.5-flash-lite`: 1M tokens, fastest, lowest-cost 3.5 model for high-throughput execution
 - `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
 - `gemini-3.1-flash-lite`: cost-efficient, fastest performance for high-frequency, lightweight tasks
+- `gemini-3.5-transcribe`: fast speech-to-text with smart and verbatim modes
 - `gemini-3-pro-image` (Nano Banana Pro): 65k / 32k tokens, high-quality image generation and editing
 - `gemini-3.1-flash-image` (Nano Banana 2): 65k / 32k tokens, fast, efficient image generation and editing
 - `gemini-3.1-flash-lite-image` (Nano Banana 2 Lite): 65k / 32k tokens, ultra-fast image generation and editing
@@ -352,6 +353,7 @@ For streaming with tools, thinking, agents, and image generation see the full [S
 
 **Multimodal Understanding:**
 - [Audio](https://ai.google.dev/gemini-api/docs/interactions/audio.md.txt)
+- [Audio Transcription](https://ai.google.dev/gemini-api/docs/transcribe.md.txt)
 - [Video Understanding](https://ai.google.dev/gemini-api/docs/interactions/video-understanding.md.txt)
 - [Document Processing](https://ai.google.dev/gemini-api/docs/interactions/document-processing.md.txt)
 

--- a/skills/gemini-live-api-dev/SKILL.md
+++ b/skills/gemini-live-api-dev/SKILL.md
@@ -253,7 +253,7 @@ To enable translation, specify a `TranslationConfig` object inside your live ses
 
 ## Live Streaming Transcription (Gemini Live Transcribe)
 
-The Live API supports real-time streaming speech-to-text over WebSockets with low-latency interim hypotheses, finalized transcripts, and Hybrid VAD. For full details, see the [Live Transcription Guide](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe.md.txt) and [Colab Cookbook](https://colab.research.google.com/drive/1py8z3YscD9SaYBshBW7k6y6V6TbcB8PF).
+The Live API supports real-time streaming speech-to-text over WebSockets with low-latency interim hypotheses, finalized transcripts, and Hybrid VAD. For full details, see the [Live Transcription Guide](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe.md.txt) and [Colab Cookbook](https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Get_started_transcribe.ipynb).
 
 ### Model
 - `gemini-3.5-transcribe-live`

--- a/skills/gemini-live-api-dev/SKILL.md
+++ b/skills/gemini-live-api-dev/SKILL.md
@@ -281,7 +281,7 @@ async with client.aio.live.connect(model="gemini-3.5-transcribe-live", config=co
 const session = await ai.live.connect({
   model: 'gemini-3.5-transcribe-live',
   config: {
-    responseModalities: [Modality.TEXT],
+    responseModalities: ['text'],
     inputAudioTranscription: { mode: 'smart' }
   },
   callbacks: {

--- a/skills/gemini-live-api-dev/SKILL.md
+++ b/skills/gemini-live-api-dev/SKILL.md
@@ -27,6 +27,7 @@ Key capabilities:
 ## Models
 
 - `gemini-3.1-flash-live-preview` — Optimized for low-latency, real-time dialogue. Native audio output, thinking (via `thinkingLevel`). 128k context window. **This is the recommended model for all Live API use cases.**
+- `gemini-3.5-transcribe-live` — Real-time streaming speech-to-text with interim hypotheses, finalized transcripts, smart formatting, and Hybrid VAD.
 - `gemini-3.5-live-translate-preview` — Real-time streaming translation model.
 
 > [!WARNING]
@@ -250,6 +251,75 @@ To enable translation, specify a `TranslationConfig` object inside your live ses
 
 ---
 
+## Live Streaming Transcription (Gemini Live Transcribe)
+
+The Live API supports real-time streaming speech-to-text over WebSockets with low-latency interim hypotheses, finalized transcripts, and Hybrid VAD. For full details, see the [Live Transcription Guide](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe.md.txt) and [Colab Cookbook](https://colab.research.google.com/drive/1py8z3YscD9SaYBshBW7k6y6V6TbcB8PF).
+
+### Model
+- `gemini-3.5-transcribe-live`
+
+### Modes
+- `smart`: cleans up filler words, resolves inline self-corrections, and structures formatting.
+- `verbatim` (default): exact word-for-word transcript.
+
+### Python
+```python
+config = types.LiveConnectConfig(
+    response_modalities=["TEXT"],
+    input_audio_transcription=types.AudioTranscriptionConfig(),
+)
+
+async with client.aio.live.connect(model="gemini-3.5-transcribe-live", config=config) as session:
+    # Stream audio
+    await session.send_realtime_input(audio=types.Blob(data=chunk, mime_type="audio/pcm;rate=16000"))
+    # Hybrid VAD: notify turn end on client-detected silence for zero latency
+    await session.send_realtime_input(audio_stream_end=True)
+```
+
+### JavaScript
+```javascript
+const session = await ai.live.connect({
+  model: 'gemini-3.5-transcribe-live',
+  config: {
+    responseModalities: [Modality.TEXT],
+    inputAudioTranscription: { mode: 'smart' }
+  },
+  callbacks: {
+    onmessage: (msg) => {
+      if (msg.serverContent?.interimInputTranscription) {
+        console.log('Interim:', msg.serverContent.interimInputTranscription.text);
+      }
+      if (msg.serverContent?.inputTranscription) {
+        console.log('Final:', msg.serverContent.inputTranscription.text);
+      }
+    }
+  }
+});
+
+session.sendRealtimeInput({ audio: { data: chunkBase64, mimeType: 'audio/pcm;rate=16000' } });
+session.sendRealtimeInput({ audioStreamEnd: true }); // Hybrid VAD
+```
+
+### Raw WebSockets
+```json
+{
+  "setup": {
+    "model": "models/gemini-3.5-transcribe-live",
+    "generationConfig": {
+      "responseModalities": ["TEXT"],
+      "speechConfig": {
+        "voiceConfig": {}
+      }
+    },
+    "inputAudioTranscription": {
+      "mode": "smart"
+    }
+  }
+}
+```
+
+---
+
 ## Limitations
 
 - **Response modality** — Only `TEXT` **or** `AUDIO` per session, not both. Native audio models only support audio.
@@ -316,6 +386,7 @@ This index contains links to all documentation pages in `.md.txt` format. Use we
 > Those are not all the documentation pages. Use the `llms.txt` index to discover available documentation pages
 
 - [Live API Overview](https://ai.google.dev/gemini-api/docs/live.md.txt) — getting started, raw WebSocket usage
+- [Live Transcription](https://ai.google.dev/gemini-api/docs/live-api/live-transcribe.md.txt) — real-time speech-to-text, interim hypotheses, smart formatting, and Hybrid VAD
 - [Live Translate](https://ai.google.dev/gemini-api/docs/live-api/live-translate.md.txt) — configuration options and capabilities for translation
 - [Live API Capabilities Guide](https://ai.google.dev/gemini-api/docs/live-guide.md.txt) — voice config, transcription config, native audio (thinking), VAD configuration, media resolution
 - [Live API Tool Use](https://ai.google.dev/gemini-api/docs/live-tools.md.txt) — function calling (sync and async), Google Search grounding


### PR DESCRIPTION
Adds support and documentation for the standalone Gemini 3.5 Transcribe launch:

- **`gemini-3.5-transcribe` (Unary)**: Speech-to-text with smart and verbatim modes. Added to `gemini-api-dev` and `gemini-interactions-api`.
- **`gemini-3.5-transcribe-live` (Live API)**: Real-time streaming speech-to-text with interim hypotheses, finalized transcripts, smart formatting, and Hybrid VAD (`audio_stream_end=True`). Added to `gemini-live-api-dev` with dual SDK (Python / JS) and WebSocket examples.
