### PR TITLE
feat: update skills for gemini-3.8-flash

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gemini-skills",
-      "version": "1.1.0",
+      "version": "2.1.0",
       "description": "A library of skills for the Gemini API, SDK and model interactions.",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "A library of skills for the Gemini API, SDK and model interactions.",
-    "version": "1.1.0"
+    "version": "2.1.0"
   },
   "plugins": [
     {
       "name": "gemini-skills",
       "description": "A library of skills for the Gemini API, SDK and model interactions.",
-      "version": "1.1.0",
+      "version": "2.1.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-skills",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A library of skills for the Gemini API, SDK and model interactions.",
   "author": {
     "name": "Google"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-skills",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A library of skills for the Gemini API, SDK and model interactions.",
   "author": {
     "name": "Google"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-skills",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A library of skills for the Gemini API, SDK and model interactions.",
   "author": {
     "name": "Google"

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-skills",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A library of skills for the Gemini API, SDK and model interactions.",
   "author": {
     "name": "Google"

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -12,7 +12,7 @@ description: Use this skill when writing code that calls the Gemini API for text
 
 ### Current Models (Use These)
 
-- `gemini-3.7-flash`: 1M tokens, fast, balanced performance for agentic and multimodal tasks
+- `gemini-3.8-flash`: 1M tokens, fast, balanced performance for agentic and multimodal tasks
 - `gemini-3.5-flash-lite`: 1M tokens, fastest, lowest-cost 3.5 model for high-throughput execution
 - `gemini-3.1-pro-preview`: 1M tokens, complex reasoning, coding, research
 - `gemini-3.1-flash-lite`: cost-efficient, fastest performance for high-frequency, lightweight tasks
@@ -29,7 +29,7 @@ description: Use this skill when writing code that calls the Gemini API for text
 
 > [!WARNING]
 > Models like `gemini-2.5-*`, `gemini-2.0-*`, `gemini-1.5-*` are **legacy and deprecated**. Never use them.
-> **If a user asks for a deprecated model, use `gemini-3.7-flash` instead and note the substitution.**
+> **If a user asks for a deprecated model, use `gemini-3.8-flash` instead and note the substitution.**
 
 ### Current Agents
 
@@ -56,7 +56,7 @@ description: Use this skill when writing code that calls the Gemini API for text
 - **Managed agents** require `environment="remote"` (or an environment ID / config object) to provision a sandbox.
 - **Migrating from `generateContent`**: Read `references/migration.md` for the scoping, checklist, and before/after code examples. Always confirm scope with the user before editing.
 - **Model upgrades**: Drop-in, swap the model string. Deprecated models (`gemini-2.0-*`, `gemini-1.5-*`) must be replaced, see `references/migration.md`.
-- **Migrating to Gemini 3.7 Flash or Gemini 3.5 Flash-Lite**: Read `references/migration.md` for the scoping and checklist.
+- **Migrating to Gemini 3.8 Flash or Gemini 3.5 Flash-Lite**: Read `references/migration.md` for the scoping and checklist.
 
 ## Quick Start
 
@@ -67,7 +67,7 @@ from google import genai
 client = genai.Client()
 
 interaction = client.interactions.create(
-    model="gemini-3.7-flash",
+    model="gemini-3.8-flash",
     input="Tell me a short joke about programming."
 )
 print(interaction.output_text)
@@ -80,7 +80,7 @@ import { GoogleGenAI } from "@google/genai";
 const client = new GoogleGenAI({});
 
 const interaction = await client.interactions.create({
-    model: "gemini-3.7-flash",
+    model: "gemini-3.8-flash",
     input: "Tell me a short joke about programming.",
 });
 console.log(interaction.output_text);
@@ -101,12 +101,12 @@ The SDK provides convenience properties on the `Interaction` response object to 
 ### Python
 ```python
 interaction1 = client.interactions.create(
-    model="gemini-3.7-flash",
+    model="gemini-3.8-flash",
     input="Hi, my name is Phil."
 )
 # Second turn — server remembers context
 interaction2 = client.interactions.create(
-    model="gemini-3.7-flash",
+    model="gemini-3.8-flash",
     input="What is my name?",
     previous_interaction_id=interaction1.id
 )
@@ -116,11 +116,11 @@ print(interaction2.output_text)
 ### JavaScript/TypeScript
 ```typescript
 const interaction1 = await client.interactions.create({
-    model: "gemini-3.7-flash",
+    model: "gemini-3.8-flash",
     input: "Hi, my name is Phil.",
 });
 const interaction2 = await client.interactions.create({
-    model: "gemini-3.7-flash",
+    model: "gemini-3.8-flash",
     input: "What is my name?",
     previous_interaction_id: interaction1.id,
 });
@@ -178,7 +178,7 @@ while (true) {
 }
 ```
 
-Advanced features: collaborative planning, native visualization, MCP integration, file search, multimodal inputs. See [Deep Research docs](https://ai.google.dev/gemini-api/docs/interactions/deep-research.md.txt).
+Advanced features: collaborative planning, native visualization, MCP integration, file search, multimodal inputs. See [Deep Research docs](https://ai.google.dev/gemini-api/docs/deep-research.md.txt).
 
 ## Managed Agents
 
@@ -286,7 +286,7 @@ Set `stream=True` to receive incremental server-sent events. Each stream follows
 ### Python
 ```python
 for event in client.interactions.create(
-    model="gemini-3.7-flash",
+    model="gemini-3.8-flash",
     input="Explain quantum entanglement in simple terms.",
     stream=True,
 ):
@@ -300,7 +300,7 @@ for event in client.interactions.create(
 ### JavaScript/TypeScript
 ```typescript
 const stream = await client.interactions.create({
-    model: "gemini-3.7-flash",
+    model: "gemini-3.8-flash",
     input: "Explain quantum entanglement in simple terms.",
     stream: true,
 });
@@ -315,7 +315,7 @@ for await (const event of stream) {
 }
 ```
 
-For streaming with tools, thinking, agents, and image generation see the full [Streaming guide](https://ai.google.dev/gemini-api/docs/interactions/streaming.md.txt).
+For streaming with tools, thinking, agents, and image generation see the full [Streaming guide](https://ai.google.dev/gemini-api/docs/streaming.md.txt).
 
 
 
@@ -325,57 +325,58 @@ For streaming with tools, thinking, agents, and image generation see the full [S
 
 **Core Documentation:**
 - [Interactions API Overview](https://ai.google.dev/gemini-api/docs/interactions.md.txt)
-- [Quickstart](https://ai.google.dev/gemini-api/docs/interactions/quickstart.md.txt)
-- [Text Generation](https://ai.google.dev/gemini-api/docs/interactions/text-generation.md.txt)
-- [Streaming](https://ai.google.dev/gemini-api/docs/interactions/streaming.md.txt)
-- [Tokens](https://ai.google.dev/gemini-api/docs/interactions/tokens.md.txt)
-- [API Keys](https://ai.google.dev/gemini-api/docs/interactions/api-key.md.txt)
+- [Quickstart](https://ai.google.dev/gemini-api/docs/quickstart.md.txt)
+- [Text Generation](https://ai.google.dev/gemini-api/docs/text-generation.md.txt)
+- [Streaming](https://ai.google.dev/gemini-api/docs/streaming.md.txt)
+- [Tokens](https://ai.google.dev/gemini-api/docs/tokens.md.txt)
+- [API Keys](https://ai.google.dev/gemini-api/docs/api-key.md.txt)
 
 **Tools & Function Calling:**
-- [Function Calling](https://ai.google.dev/gemini-api/docs/interactions/function-calling.md.txt)
-- [Google Search](https://ai.google.dev/gemini-api/docs/interactions/google-search.md.txt)
-- [Code Execution](https://ai.google.dev/gemini-api/docs/interactions/code-execution.md.txt)
-- [URL Context](https://ai.google.dev/gemini-api/docs/interactions/url-context.md.txt)
-- [File Search](https://ai.google.dev/gemini-api/docs/interactions/file-search.md.txt)
-- [Tool Combination](https://ai.google.dev/gemini-api/docs/interactions/tool-combination.md.txt)
-- [Computer Use](https://ai.google.dev/gemini-api/docs/interactions/computer-use.md.txt)
-- [Maps Grounding](https://ai.google.dev/gemini-api/docs/interactions/maps-grounding.md.txt)
+- [Function Calling](https://ai.google.dev/gemini-api/docs/function-calling.md.txt)
+- [Google Search](https://ai.google.dev/gemini-api/docs/google-search.md.txt)
+- [Code Execution](https://ai.google.dev/gemini-api/docs/code-execution.md.txt)
+- [URL Context](https://ai.google.dev/gemini-api/docs/url-context.md.txt)
+- [File Search](https://ai.google.dev/gemini-api/docs/file-search.md.txt)
+- [Tool Combination](https://ai.google.dev/gemini-api/docs/tool-combination.md.txt)
+- [Computer Use](https://ai.google.dev/gemini-api/docs/computer-use.md.txt)
+- [Maps Grounding](https://ai.google.dev/gemini-api/docs/maps-grounding.md.txt)
 
 **Generation & Output:**
-- [Structured Output](https://ai.google.dev/gemini-api/docs/interactions/structured-output.md.txt)
-- [Thinking](https://ai.google.dev/gemini-api/docs/interactions/thinking.md.txt)
-- [Thought Signatures](https://ai.google.dev/gemini-api/docs/interactions/thought-signatures.md.txt)
-- [Image Generation](https://ai.google.dev/gemini-api/docs/interactions/image-generation.md.txt)
-- [Image Understanding](https://ai.google.dev/gemini-api/docs/interactions/image-understanding.md.txt)
+- [Structured Output](https://ai.google.dev/gemini-api/docs/structured-output.md.txt)
+- [Thinking](https://ai.google.dev/gemini-api/docs/thinking.md.txt)
+- [Thought Signatures](https://ai.google.dev/gemini-api/docs/thought-signatures.md.txt)
+- [Image Generation](https://ai.google.dev/gemini-api/docs/image-generation.md.txt)
+- [Image Understanding](https://ai.google.dev/gemini-api/docs/image-understanding.md.txt)
 - [Video Generation & Editing (Omni Flash)](https://ai.google.dev/gemini-api/docs/omni.md.txt)
-- [Speech Generation](https://ai.google.dev/gemini-api/docs/interactions/speech-generation.md.txt)
-- [Music Generation](https://ai.google.dev/gemini-api/docs/interactions/music-generation.md.txt)
+- [Speech Generation](https://ai.google.dev/gemini-api/docs/speech-generation.md.txt)
+- [Music Generation](https://ai.google.dev/gemini-api/docs/music-generation.md.txt)
 - [Embeddings](https://ai.google.dev/gemini-api/docs/embeddings.md.txt)
 
 **Multimodal Understanding:**
-- [Audio](https://ai.google.dev/gemini-api/docs/interactions/audio.md.txt)
+- [Audio](https://ai.google.dev/gemini-api/docs/audio.md.txt)
 - [Audio Transcription](https://ai.google.dev/gemini-api/docs/transcribe.md.txt)
-- [Video Understanding](https://ai.google.dev/gemini-api/docs/interactions/video-understanding.md.txt)
-- [Document Processing](https://ai.google.dev/gemini-api/docs/interactions/document-processing.md.txt)
+- [Video Understanding](https://ai.google.dev/gemini-api/docs/video-understanding.md.txt)
+- [Document Processing](https://ai.google.dev/gemini-api/docs/document-processing.md.txt)
 
 **Files & Context:**
-- [Files](https://ai.google.dev/gemini-api/docs/interactions/files.md.txt)
-- [File Input Methods](https://ai.google.dev/gemini-api/docs/interactions/file-input-methods.md.txt)
-- [Caching](https://ai.google.dev/gemini-api/docs/interactions/caching.md.txt)
-- [Media Resolution](https://ai.google.dev/gemini-api/docs/interactions/media-resolution.md.txt)
+- [Files](https://ai.google.dev/gemini-api/docs/files.md.txt)
+- [File Input Methods](https://ai.google.dev/gemini-api/docs/file-input-methods.md.txt)
+- [Caching](https://ai.google.dev/gemini-api/docs/caching.md.txt)
+- [Media Resolution](https://ai.google.dev/gemini-api/docs/media-resolution.md.txt)
 
 **Agents:**
 - [Agents Overview](https://ai.google.dev/gemini-api/docs/agents.md.txt)
 - [Managed Agents Quickstart](https://ai.google.dev/gemini-api/docs/managed-agents-quickstart.md.txt)
 - [Antigravity Agent](https://ai.google.dev/gemini-api/docs/antigravity-agent.md.txt)
 - [Agent Environments](https://ai.google.dev/gemini-api/docs/agent-environment.md.txt)
+- [Agent Hooks](https://ai.google.dev/gemini-api/docs/agent-hooks.md.txt)
 - [Building Custom Agents](https://ai.google.dev/gemini-api/docs/custom-agents.md.txt)
-- [Deep Research](https://ai.google.dev/gemini-api/docs/interactions/deep-research.md.txt)
+- [Deep Research](https://ai.google.dev/gemini-api/docs/deep-research.md.txt)
 
 **Advanced Features:**
-- [Latest Models (3.7 Flash & 3.5 Flash-Lite)](https://ai.google.dev/gemini-api/docs/latest-model.md.txt)
-- [Flex Inference](https://ai.google.dev/gemini-api/docs/interactions/flex-inference.md.txt)
-- [Priority Inference](https://ai.google.dev/gemini-api/docs/interactions/priority-inference.md.txt)
+- [Latest Models (3.8 Flash & 3.5 Flash-Lite)](https://ai.google.dev/gemini-api/docs/latest-model.md.txt)
+- [Flex Inference](https://ai.google.dev/gemini-api/docs/flex-inference.md.txt)
+- [Priority Inference](https://ai.google.dev/gemini-api/docs/priority-inference.md.txt)
 
 **API Reference:**
 - [API Reference](https://ai.google.dev/static/api/interactions.md.txt)

--- a/skills/gemini-api-dev/references/migration.md
+++ b/skills/gemini-api-dev/references/migration.md
@@ -18,7 +18,7 @@ Even imperative requests like "migrate my code", "upgrade to gemini 3", "migrate
 **Sizing the scope (large repos).** Before asking, get a per-directory count:
 
 ```sh
-rg -l "generate_content|generateContent|gemini-2\.0|gemini-1\.5|gemini-2\.5|gemini-3\.5|gemini-3\.6|gemini-3\.7|thinking_budget|temperature" --type-not md | cut -d/ -f1 | sort | uniq -c | sort -rn
+rg -l "generate_content|generateContent|gemini-1\.5|gemini-2\.0|gemini-2\.5|gemini-3\.1-flash-lite|gemini-3\.5|gemini-3\.6|gemini-3\.7|gemini-3-flash|thinking_budget|temperature" --type-not md | cut -d/ -f1 | sort | uniq -c | sort -rn
 ```
 
 Present the breakdown in your question (e.g. *"Found 42 references across 3 directories: src/ (28), tests/ (10), scripts/ (4). Which to migrate?"*).
@@ -50,17 +50,17 @@ For full before/after code examples, fetch the [Migration Guide](https://ai.goog
 
 | Model | Status | Drop-in Replacement |
 |-------|--------|-------------------|
-| `gemini-2.0-flash` | Deprecated | `gemini-3.7-flash` |
+| `gemini-2.0-flash` | Deprecated | `gemini-3.8-flash` |
 | `gemini-2.0-flash-lite` | Deprecated | `gemini-3.5-flash-lite` |
-| `gemini-1.5-pro` | Deprecated | `gemini-3.7-flash` |
-| `gemini-1.5-flash` | Deprecated | `gemini-3.7-flash` |
+| `gemini-1.5-pro` | Deprecated | `gemini-3.8-flash` |
+| `gemini-1.5-flash` | Deprecated | `gemini-3.8-flash` |
 
 ### Active Legacy Models (migration recommended)
 
 | Current Model | Recommended Target | Why |
 |--------------|-------------------|-----|
-| `gemini-3.6-flash`, `gemini-3.5-flash`, or `gemini-3-flash-preview` | `gemini-3.7-flash` | Latest Flash: stronger agentic/multimodal performance, reduced token usage/loop spiraling |
-| `gemini-2.5-flash` | `gemini-3.7-flash` or `gemini-3.5-flash-lite` | Latest Flash with Interactions API support, or latest Flash-Lite for cheaper/simpler tasks. |
+| `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, or `gemini-3-flash-preview` | `gemini-3.8-flash` | Latest Flash: stronger agentic/multimodal performance, reduced token usage/loop spiraling |
+| `gemini-2.5-flash` | `gemini-3.8-flash` or `gemini-3.5-flash-lite` | Latest Flash with Interactions API support, or latest Flash-Lite for cheaper/simpler tasks. |
 | `gemini-2.5-flash-lite` or `gemini-3.1-flash-lite` | `gemini-3.5-flash-lite` | Latest Flash-lite with Interactions API support |
 | `gemini-2.5-pro` | `gemini-3.1-pro-preview` | Latest Pro with 1M context, complex reasoning |
 
@@ -91,19 +91,20 @@ Every item is tagged: **`[BLOCKS]`** items cause errors or broken behavior if mi
 
 - [ ] Replaced `gemini-2.0-*` model strings with current equivalents
 - [ ] Replaced `gemini-1.5-*` model strings with current equivalents
-- [ ] Consider upgrading `gemini-3.6-flash` → `gemini-3.7-flash`
-- [ ] Consider upgrading `gemini-3.5-flash` → `gemini-3.7-flash`
-- [ ] Consider upgrading `gemini-3-flash-preview` → `gemini-3.7-flash`
-- [ ] Consider upgrading `gemini-2.5-flash` → `gemini-3.7-flash`
+- [ ] Consider upgrading `gemini-3.7-flash` → `gemini-3.8-flash`
+- [ ] Consider upgrading `gemini-3.6-flash` → `gemini-3.8-flash`
+- [ ] Consider upgrading `gemini-3.5-flash` → `gemini-3.8-flash`
+- [ ] Consider upgrading `gemini-3-flash-preview` → `gemini-3.8-flash`
+- [ ] Consider upgrading `gemini-2.5-flash` → `gemini-3.8-flash`
 - [ ] Consider upgrading `gemini-3.1-flash-lite` → `gemini-3.5-flash-lite`
 - [ ] Consider upgrading `gemini-2.5-flash-lite` → `gemini-3.5-flash-lite` or `gemini-3.1-flash-lite`
 - [ ] Consider upgrading `gemini-2.5-pro` → `gemini-3.1-pro-preview`
 
-### Migrate to Gemini 3.7 Flash or Gemini 3.5 Flash-Lite
+### Migrate to Gemini 3.8 Flash or Gemini 3.5 Flash-Lite
 
-Use this checklist if the user requests to migrate to Gemini 3.7 Flash or Gemini 3.5 Flash-Lite. For full documentation of the changes, fetch the [Latest Gemini models guide](https://ai.google.dev/gemini-api/docs/latest-model.md.txt) and look for the migration section.
+Use this checklist if the user requests to migrate to Gemini 3.8 Flash or Gemini 3.5 Flash-Lite. For full documentation of the changes, fetch the [Latest Gemini models guide](https://ai.google.dev/gemini-api/docs/latest-model.md.txt) and look for the migration section.
 
-- [ ] Updated model name to `gemini-3.7-flash` or `gemini-3.5-flash-lite` (depending on user request)
+- [ ] Updated model name to `gemini-3.8-flash` or `gemini-3.5-flash-lite` (depending on user request)
 - [ ] Removed `temperature`, `top_p`, `top_k` from config
 - [ ] Replaced `thinking_budget` with `thinking_level` (`minimal`, `low`, `medium`, `high`)
 

--- a/skills/gemini-omni-flash-api/SKILL.md
+++ b/skills/gemini-omni-flash-api/SKILL.md
@@ -32,7 +32,7 @@ This skill uses the Gemini Omni 1.1 Flash model (`gemini-omni-1.1-flash`) to per
 ## Reference Documentation
 
 * **Interactions API**: All operations and state management for the Gemini Omni 1.1 Flash model (`gemini-omni-1.1-flash`) are handled via the [Interactions API](https://ai.google.dev/gemini-api/docs/interactions-overview).
-* **Files API**: Input media files (such as reference images and videos) must be uploaded via the [Files API](https://ai.google.dev/gemini-api/docs/interactions/files) first before being referenced in generations. The uploaded file URI and MIME type are then included in the `interactions.create` input parts array.
+* **Files API**: Input media files (such as reference images and videos) must be uploaded via the [Files API](https://ai.google.dev/gemini-api/docs/files) first before being referenced in generations. The uploaded file URI and MIME type are then included in the `interactions.create` input parts array.
 * **[Gemini API Skill Reference](https://github.com/google-gemini/gemini-skills/blob/main/skills/gemini-api-dev/SKILL.md)**: Platform-wide guidelines, current model specifications, and SDK usage rules for the Gemini API.
 
 ## Dependencies and Prerequisites


### PR DESCRIPTION
## Summary

- **Gemini 3.8 Flash**:
  - Update `gemini-api-dev` skill to recommend `gemini-3.8-flash` as current flagship Flash model.
  - Update code examples (Python and TypeScript) across quickstart, multi-turn stateful conversations, and streaming to use `gemini-3.8-flash`.
  - Update migration reference tables and checklist to target `gemini-3.8-flash`, adding `gemini-3.7-flash` as an upgrade source.
  - Refine scoping `rg` command to accurately target legacy models (`gemini-3.1-flash-lite`, `gemini-3-flash`, etc.) without false positives on already-migrated `gemini-3.8-flash` code.
- **Canonical Documentation Links**:
  - Replace legacy `/interactions/*` documentation paths with canonical URLs across `gemini-api-dev` and `gemini-omni-flash-api`.
  - Add `Agent Hooks` documentation link under `**Agents:**`.
  - Update `Video Understanding` link to canonical `https://ai.google.dev/gemini-api/docs/video-understanding.md.txt`.
- **Plugin Version**:
  - Bump plugin version from `2.0.0` to `2.1.0` across plugins and marketplace manifests.